### PR TITLE
chore: del include config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,11 +18,5 @@
   "vueCompilerOptions": {
     // 调整 Volar（Vue 语言服务工具）解析行为，用于为 uni-app 组件提供 TypeScript 类型
     "plugins": ["@uni-helper/uni-types/volar-plugin"]
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue"
-  ]
+  }
 }


### PR DESCRIPTION
### Description 描述

解决 Vue (Official) > 3.0.7 根目录相关配置文件感知失效的问题

### Linked Issues 关联的 Issues

https://github.com/vuejs/language-tools/issues/5665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript project configuration to rely on default file inclusion.
  * Affects only which files are considered during type-checking and compilation.
  * No changes to application behavior or user-facing features.
  * Developers may notice differences in editor/type-checking coverage, but builds and runtime remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->